### PR TITLE
Add libWrapper support

### DIFF
--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -32,10 +32,10 @@ export function Patch_Token_onUpdate() {
         // if the original _onUpdate didn't perform a sight layer update,
         // but elevation has changed, do the update now
         if (changed.has("elevation") && !alreadyUpdated) {
-            canvas.sight.updateToken(this, { defer: true });
-            canvas.addPendingOperation("SightLayer.update", canvas.sight.update, canvas.sight);
-            canvas.addPendingOperation("LightingLayer.update", canvas.lighting.update, canvas.lighting);
-            canvas.addPendingOperation(`SoundLayer.update`, canvas.sounds.update, canvas.sounds);
+            this.updateSource({ defer: true });
+            canvas.addPendingOperation("SightLayer.refresh", canvas.sight.refresh, canvas.sight);
+            canvas.addPendingOperation("LightingLayer.refresh", canvas.lighting.refresh, canvas.lighting);
+            canvas.addPendingOperation(`SoundLayer.refresh`, canvas.sounds.refresh, canvas.sounds);
         }
     };
 

--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -2,9 +2,10 @@ import { MODULE_SCOPE, TOP_KEY, BOTTOM_KEY } from "./const.js";
 import { getWallBounds } from "./utils.js";
 
 export function Patch_Token_onUpdate() {
-    const oldOnUpdate = Token.prototype._onUpdate;
-    Token.prototype._onUpdate = function (data, options) {
-        oldOnUpdate.apply(this, arguments);
+    const onUpdate = function (wrapped, ...args) {
+        const [ data, options ] = args;
+
+        wrapped(...args);
 
         const changed = new Set(Object.keys(data));
 
@@ -37,29 +38,52 @@ export function Patch_Token_onUpdate() {
             canvas.addPendingOperation(`SoundLayer.update`, canvas.sounds.update, canvas.sounds);
         }
     };
+
+    if (game.modules.get("lib-wrapper")?.active) {
+        libWrapper.register("wall-height", "Token.prototype._onUpdate", onUpdate, "WRAPPER");
+    } else {
+        const oldOnUpdate = Token.prototype._onUpdate;
+        Token.prototype._onUpdate = function () {
+            return onUpdate.call(this, oldOnUpdate.bind(this), ...arguments);
+        }
+    }
 }
 
 export function Patch_WallCollisions() {
     // store the token elevation in a common scope, so that it can be used by the following functions without needing to pass it explicitly
     let currentTokenElevation = null;
 
-    const oldTokenUpdateSource = Token.prototype.updateSource;
-    Token.prototype.updateSource = function () {
+    const updateSource = function (wrapped, ...args) {
         currentTokenElevation = this.data.elevation;
-        oldTokenUpdateSource.apply(this, arguments);
+        wrapped(...args);
         currentTokenElevation = null;
     };
 
-    const oldWallsLayerTestWall = WallsLayer.testWall;
-    WallsLayer.testWall = function (ray, wall) {
+    const testWall = function (wrapped, ...args) {
+        const [ ray, wall ] = args;
         const { wallHeightTop, wallHeightBottom } = getWallBounds(wall);
         if (
             currentTokenElevation == null ||
             (currentTokenElevation >= wallHeightBottom && currentTokenElevation < wallHeightTop)
         ) {
-            return oldWallsLayerTestWall.apply(this, arguments);
+            return wrapped(...args);
         } else {
             return null;
         }
     };
+
+    if (game.modules.get("lib-wrapper")?.active) {
+        libWrapper.register("wall-height", "Token.prototype.updateSource", updateSource, "WRAPPER");
+        libWrapper.register("wall-height", "WallsLayer.testWall", testWall, "MIXED");
+    } else {
+        const oldTokenUpdateSource = Token.prototype.updateSource;
+        Token.prototype.updateSource = function () {
+            return updateSource.call(this, oldTokenUpdateSource.bind(this), ...arguments);
+        }
+
+        const oldWallsLayerTestWall = WallsLayer.testWall;
+        WallsLayer.testWall = function () {
+            return testWall.call(this, oldWallsLayerTestWall.bind(this), ...arguments);
+        }
+    }
 }

--- a/scripts/wall-height.js
+++ b/scripts/wall-height.js
@@ -2,9 +2,14 @@ import { Patch_Token_onUpdate, Patch_WallCollisions } from "./patches.js";
 import { MODULE_SCOPE, TOP_KEY, BOTTOM_KEY } from "./const.js";
 import { getWallBounds } from "./utils.js";
 
-Hooks.on("init", () => {
+Hooks.once("init", () => {
     Patch_Token_onUpdate();
     Patch_WallCollisions();
+});
+
+Hooks.once("ready", () => {
+    if (!game.modules.get("lib-wrapper")?.active && game.user.isGM)
+        ui.notifications.warn("The 'Wall Height' module recommends to install and activate the 'libWrapper' module.");
 });
 
 Hooks.on("renderWallConfig", (app, html, data) => {


### PR DESCRIPTION
Use libWrapper to patch functions if possible; otherwise patch as before. Gives the GM the recommendation to enable the libWrapper module.

I also replaced deprecated methods (#15) and updated the `Token.prototype._onUpdate` patch to Foundry 0.7.8.